### PR TITLE
Add health endpoint and pytest

### DIFF
--- a/docs/prd.txt
+++ b/docs/prd.txt
@@ -1,0 +1,35 @@
+Product Requirements Document - Gene Variant Annotation MCP Service
+-------------------------------------------------------------------
+
+Overview:
+This service exposes the existing variant annotation functionality as a HTTP
+microservice. It communicates with the open CIViC API to retrieve oncology
+variant data.
+
+Features:
+1. **Gene Variant Query**
+   - Endpoint: `GET /gene/{gene}`
+   - Returns a list of variants for the provided gene symbol.
+2. **Variant Details**
+   - Endpoint: `GET /variant/{variant_id}`
+   - Returns details for a specific CIViC variant ID.
+3. **Health Check**
+   - Endpoint: `GET /health`
+   - Returns `{ "status": "ok" }` when the service is running.
+4. **Error Handling**
+   - API returns HTTP 404 when the CIViC API reports missing data.
+5. **Service Execution**
+   - Starts with `python variant_service.py` which runs `uvicorn` on port 8000.
+
+Dependencies:
+- fastapi
+- uvicorn
+- pytest
+
+Future Enhancements:
+- Authentication/authorization for access control
+- Rate limiting to protect the CIViC API
+
+The service reuses logic from `variant_annotator.py` and does not store any
+state. It serves as an integration point for other MCP components that need
+programmatic access to cancer variant information.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/variant_service.py
+++ b/variant_service.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, HTTPException
+from urllib.error import HTTPError
+
+from variant_annotator import fetch_variants_by_gene, fetch_variant
+
+app = FastAPI(title="Gene Variant Annotation Service")
+
+
+@app.get("/health")
+def health():
+    """Simple health check used for monitoring."""
+    return {"status": "ok"}
+
+
+@app.get("/gene/{gene}")
+def get_variants(gene: str):
+    """Return variants for a given gene symbol."""
+    try:
+        return fetch_variants_by_gene(gene)
+    except HTTPError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@app.get("/variant/{variant_id}")
+def get_variant(variant_id: int):
+    """Return details for a specific variant id."""
+    try:
+        return fetch_variant(variant_id)
+    except HTTPError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- expand PRD with health endpoint and future ideas
- expose `/health` route in `variant_service`
- list `pytest` as a dependency

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*