### PR TITLE
Add MCP integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ The `docs/` directory contains a basic site that can be published with GitHub Pa
 
 - Python 3.8+
 
+## Model Context Protocol Integration
+
+The `variant_service.py` microservice can be used in a Model Context Protocol
+workflow. AI models running on an MCP server can call the service's endpoints to
+retrieve gene variant information. See [docs/mcp.md](docs/mcp.md) for details on
+the available tools.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,9 @@ python variant_annotator.py --gene TP53
 
 The tool queries the CIViC API each time it runs so information is always up to date with the latest curated variants and studies.
 
+## Related Documents
+
+- [Product Requirements](prd.txt)
+- [Task Breakdown](prd_tasks.md)
+- [Model Context Protocol Integration](mcp.md)
+

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,23 @@
+# Model Context Protocol Integration
+
+This document describes how the gene variant annotation service can be used within a Model Context Protocol (MCP) workflow. The goal is to expose gene variant information to AI models through a simple set of tools.
+
+## Available Tools
+
+- `get_gene_variants(gene_symbol: str)`
+  - Calls `GET /gene/{gene}` to retrieve all variants for the specified gene symbol.
+- `get_variant_details(variant_id: int)`
+  - Calls `GET /variant/{variant_id}` to return detailed information for a CIViC variant.
+- `health_check()`
+  - Calls `GET /health` to confirm the service is reachable.
+
+These tools allow an MCP server to fetch curated variant data from CIViC or other sources and supply it to a downstream model. They focus exclusively on gene variant queries so that the AI can reason about oncology variants without direct network access.
+
+## Example Workflow
+
+1. An MCP server receives a user question about a gene.
+2. It invokes `get_gene_variants` to gather variant candidates.
+3. Optionally store the results in a vector database for later retrieval.
+4. When a particular variant is referenced, call `get_variant_details`.
+5. The MCP passes the information to an AI model hosted on AWS Bedrock to generate a response.
+

--- a/docs/prd_tasks.md
+++ b/docs/prd_tasks.md
@@ -1,0 +1,52 @@
+# Task Breakdown for Variant Annotation Service
+
+This document lists implementation tasks derived from the PRD (`prd.txt`) and expands them into actionable steps.
+
+## 1. Gene Variant Query Endpoint
+- Implement `GET /gene/{gene}` in `variant_service.py` using `fetch_variants_by_gene`.
+- Validate that a gene symbol is supplied and handle empty input.
+- Return a JSON array of variant objects from CIViC.
+- Write unit tests covering successful queries and CIViC errors.
+- Update documentation with usage examples.
+
+## 2. Variant Details Endpoint
+- Implement `GET /variant/{variant_id}` using `fetch_variant`.
+- Validate the `variant_id` parameter and handle non-integer input.
+- Return detailed variant information in JSON format.
+- Create tests for valid and invalid IDs.
+- Document example requests and responses.
+
+## 3. Health Check Endpoint
+- Provide `GET /health` that returns `{"status": "ok"}`.
+- Add a test to verify the endpoint response.
+
+## 4. Error Handling
+- Translate CIViC API errors into HTTP 404 responses when data is missing.
+- Log other unhandled errors and return HTTP 500.
+- Unit test error scenarios for both endpoints.
+
+## 5. Service Execution
+- Ensure the service starts with `python variant_service.py` using uvicorn on port 8000.
+- Add command line options for host and port if needed.
+- Document how to run the service locally.
+
+## 6. Dependencies
+- Confirm `fastapi`, `uvicorn`, and `pytest` are listed in `requirements.txt`.
+- Provide installation instructions in the README.
+
+## 7. Future Enhancements
+- **Authentication & Authorization**
+  - Evaluate integration with token-based auth or OAuth.
+  - Restrict endpoints to authenticated clients.
+- **Rate Limiting**
+  - Add rate-limiting middleware to protect the CIViC API.
+  - Configure limits and document expected behavior.
+
+## 8. Testing & CI
+- Expand the `tests` directory with unit and integration tests for all endpoints.
+- Configure a GitHub Actions workflow to run the test suite on each commit.
+
+## 9. Documentation
+- Update `docs/index.md` with endpoint descriptions.
+- Link to `prd.txt` for context and keep `task_breakdown.md` up to date as features evolve.
+


### PR DESCRIPTION
## Summary
- document MCP integration and available tools
- link the new doc from the docs index
- mention MCP usage in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*