### PR TITLE
Add Flutter web demo and GitHub Pages workflow

### DIFF
--- a/.github/workflows/flutter-gh-pages.yml
+++ b/.github/workflows/flutter-gh-pages.yml
@@ -1,0 +1,32 @@
+name: Build and Deploy Flutter Web
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+        working-directory: flutter_web_app
+
+      - name: Build web
+        run: flutter build web --release
+        working-directory: flutter_web_app
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: flutter_web_app/build/web
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ The tool prints variant IDs, names and short descriptions retrieved from CIViC.
 
 ## GitHub Pages
 
-The `docs/` directory contains a basic site that can be published with GitHub Pages to share information and instructions.
+This repository contains a simple Flutter web application in `flutter_web_app`.
+The included GitHub Actions workflow builds the app and publishes the generated
+site to the `gh-pages` branch, enabling GitHub Pages hosting. The `docs/`
+directory remains available for additional documentation.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,10 @@ python variant_annotator.py --gene TP53
 
 The tool queries the CIViC API each time it runs so information is always up to date with the latest curated variants and studies.
 
+## Web Demo
+
+A small Flutter web demo is built from the `flutter_web_app` directory and published to GitHub Pages via the `gh-pages` branch when changes are pushed to `main`.
+
 ## Related Documents
 
 - [Product Requirements](prd.txt)

--- a/flutter_web_app/lib/main.dart
+++ b/flutter_web_app/lib/main.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Gene Variant App',
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Gene Variant Annotation Tool'),
+        ),
+        body: const Center(
+          child: Text('Hello from Flutter Web!'),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_web_app/pubspec.yaml
+++ b/flutter_web_app/pubspec.yaml
@@ -1,0 +1,17 @@
+name: variant_site
+description: A simple Flutter web page for the Gene Variant Annotation Tool.
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/flutter_web_app/web/index.html
+++ b/flutter_web_app/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Gene Variant App</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <script src="main.dart.js" type="application/javascript"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal Flutter web app
- add workflow to build Flutter web and publish to GitHub Pages
- document the workflow in README and docs

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*