### PR TITLE
Fix GH Pages deployment permissions

### DIFF
--- a/.github/workflows/flutter-gh-pages.yml
+++ b/.github/workflows/flutter-gh-pages.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant workflow write access so GitHub Pages deployment can push to `gh-pages`

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: command not found)*