### PR TITLE
Add MCP service docs and update Flutter site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The tool prints variant IDs, names and short descriptions retrieved from CIViC.
 ## GitHub Pages
 
 This repository contains a simple Flutter web application in `flutter_web_app`.
-The included GitHub Actions workflow builds the app and publishes the generated
-site to the `gh-pages` branch, enabling GitHub Pages hosting. The `docs/`
-directory remains available for additional documentation.
+The GitHub Actions workflow builds the app from the Markdown files in `docs/` and
+publishes the generated site to the `gh-pages` branch. The result is a hosted
+site with documentation about the MCP service and instructions for configuring
+it in Cursor.
 
 ## Requirements
 
@@ -28,5 +29,5 @@ directory remains available for additional documentation.
 The `variant_service.py` microservice can be used in a Model Context Protocol
 workflow. AI models running on an MCP server can call the service's endpoints to
 retrieve gene variant information. See [docs/mcp.md](docs/mcp.md) for details on
-the available tools.
+the available tools. Configuration instructions for [Cursor](https://github.com/getcursor/cursor) are provided in [docs/cursor.md](docs/cursor.md).
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -1,0 +1,21 @@
+# Configuring the Service in Cursor
+
+To call the gene variant service from [Cursor](https://github.com/getcursor/cursor), add an HTTP tool entry pointing to your running instance.
+
+1. Start the service locally:
+
+```bash
+python variant_service.py
+```
+
+2. Update `cursor.json` with the tool configuration:
+
+```json
+{
+  "tools": [
+    { "name": "variant_service", "base_url": "http://localhost:8000" }
+  ]
+}
+```
+
+Restart Cursor after saving the file. You can then invoke the service from your MCP workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Gene Variant Annotation Tool
+# Gene Variant Annotation Service
 
-This site describes how to use the command line tool to fetch the latest oncology variant data from CIViC.
+This site provides documentation for the microservice that exposes curated oncology variant information from CIViC. The service is designed for use in Model Context Protocol (MCP) workflows and can also be called directly.
 
 ## Getting Started
 
@@ -14,13 +14,15 @@ python variant_annotator.py --gene TP53
 
 The tool queries the CIViC API each time it runs so information is always up to date with the latest curated variants and studies.
 
-## Web Demo
 
-A small Flutter web demo is built from the `flutter_web_app` directory and published to GitHub Pages via the `gh-pages` branch when changes are pushed to `main`.
+## Web Documentation
+
+The content of this site is also compiled into a simple Flutter web app under `flutter_web_app` and published to the `gh-pages` branch.
 
 ## Related Documents
 
 - [Product Requirements](prd.txt)
 - [Task Breakdown](prd_tasks.md)
 - [Model Context Protocol Integration](mcp.md)
+- [Configuring in Cursor](cursor.md)
 

--- a/flutter_web_app/lib/main.dart
+++ b/flutter_web_app/lib/main.dart
@@ -7,16 +7,44 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  static const String docText = '''
+Gene Variant Annotation Service
+
+This microservice exposes endpoints to query oncology variant data for use in Model Context Protocol (MCP) workflows.
+
+Available endpoints:
+- GET /health
+- GET /gene/{gene}
+- GET /variant/{variant_id}
+
+### Configuring in Cursor
+
+1. Start the service:
+   ```bash
+   python variant_service.py
+   ```
+2. Add an entry to your `cursor.json` configuration:
+   ```json
+   {
+     "tools": [
+       { "name": "variant_service", "base_url": "http://localhost:8000" }
+     ]
+   }
+   ```
+Restart Cursor after saving the configuration.
+''';
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Gene Variant App',
+      title: 'MCP Service Docs',
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('Gene Variant Annotation Tool'),
+          title: const Text('Gene Variant Service Docs'),
         ),
-        body: const Center(
-          child: Text('Hello from Flutter Web!'),
+        body: const SingleChildScrollView(
+          padding: EdgeInsets.all(16),
+          child: SelectableText(docText),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add `docs/cursor.md` for configuring the service in Cursor
- update main documentation index
- clarify README to describe the docs site
- update Flutter web page to display service documentation

## Testing
- `pytest -q` *(fails: `pytest` not found)*