### PR TITLE
Switch to unittest

### DIFF
--- a/.github/workflows/react-gh-pages.yml
+++ b/.github/workflows/react-gh-pages.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Generate lockfile
+        run: npm install --package-lock-only
+        working-directory: react_web_app
+
       - name: Install dependencies
         run: npm ci
         working-directory: react_web_app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore node modules and build artifacts
+react_web_app/node_modules/
+react_web_app/dist/

--- a/README.md
+++ b/README.md
@@ -29,5 +29,13 @@ it in Cursor.
 The `variant_service.py` microservice can be used in a Model Context Protocol
 workflow. AI models running on an MCP server can call the service's endpoints to
 retrieve gene variant information. See [docs/mcp.md](docs/mcp.md) for details on
-the available tools. Configuration instructions for [Cursor](https://github.com/getcursor/cursor) are provided in [docs/cursor.md](docs/cursor.md).
+ the available tools. Configuration instructions for [Cursor](https://github.com/getcursor/cursor) are provided in [docs/cursor.md](docs/cursor.md).
+
+## Running Tests
+
+Run the test suite using Python's built-in `unittest` module:
+
+```bash
+python -m unittest
+```
 

--- a/docs/prd.txt
+++ b/docs/prd.txt
@@ -24,7 +24,6 @@ Features:
 Dependencies:
 - fastapi
 - uvicorn
-- pytest
 
 Future Enhancements:
 - Authentication/authorization for access control

--- a/docs/prd_tasks.md
+++ b/docs/prd_tasks.md
@@ -31,7 +31,7 @@ This document lists implementation tasks derived from the PRD (`prd.txt`) and ex
 - Document how to run the service locally.
 
 ## 6. Dependencies
-- Confirm `fastapi`, `uvicorn`, and `pytest` are listed in `requirements.txt`.
+- Confirm `fastapi` and `uvicorn` are listed in `requirements.txt`.
 - Provide installation instructions in the README.
 
 ## 7. Future Enhancements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 fastapi
 uvicorn
-pytest


### PR DESCRIPTION
## Summary
- remove pytest from requirements
- drop pytest from PRD documents
- document running tests with unittest
- generate package-lock before npm ci to fix workflow

## Testing
- `python -m unittest`
- `npm ci --prefix react_web_app` *(fails: The `npm ci` command can only install with an existing package-lock)*
