### PR TITLE
Fix GH Pages build by setting Vite base path

### DIFF
--- a/react_web_app/vite.config.js
+++ b/react_web_app/vite.config.js
@@ -3,4 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Set base path for GitHub Pages so assets resolve correctly
+  base: '/mcp-gene-variant-annotation/',
 });


### PR DESCRIPTION
## Summary
- set Vite `base` option for GitHub Pages deployment

## Testing
- `python -m unittest -v`