### PR TITLE
Add backend tests and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,22 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: python -m unittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from variant_annotator import (
+    fetch_json,
+    fetch_variants_by_gene,
+    fetch_variant,
+    CIVIC_BASE_URL,
+)
+
+
+class AnnotatorTest(unittest.TestCase):
+    def test_fetch_json(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"a": 1}'
+        mock_resp.__enter__.return_value = mock_resp
+        with patch("variant_annotator.urlopen", return_value=mock_resp) as m:
+            result = fetch_json("http://example.com")
+            self.assertEqual(result, {"a": 1})
+            m.assert_called_with("http://example.com")
+
+    def test_fetch_variants_by_gene(self):
+        with patch("variant_annotator.fetch_json", return_value=[{"id": 1}]) as m:
+            result = fetch_variants_by_gene("TP53")
+            self.assertEqual(result, [{"id": 1}])
+            m.assert_called_with(f"{CIVIC_BASE_URL}/genes/TP53/variants")
+
+    def test_fetch_variant(self):
+        with patch("variant_annotator.fetch_json", return_value={"id": 1}) as m:
+            result = fetch_variant(1)
+            self.assertEqual(result, {"id": 1})
+            m.assert_called_with(f"{CIVIC_BASE_URL}/variants/1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,46 @@
+import unittest
+from urllib.error import HTTPError
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from variant_service import health, get_variants, get_variant
+
+
+class ServiceTest(unittest.TestCase):
+    def test_health(self):
+        self.assertEqual(health(), {"status": "ok"})
+
+    @patch("variant_service.fetch_variants_by_gene")
+    def test_get_variants_success(self, mock_fetch):
+        mock_fetch.return_value = [{"id": 1, "name": "Variant"}]
+        result = get_variants("TP53")
+        self.assertEqual(result, [{"id": 1, "name": "Variant"}])
+        mock_fetch.assert_called_with("TP53")
+
+    @patch("variant_service.fetch_variants_by_gene")
+    def test_get_variants_http_error(self, mock_fetch):
+        mock_fetch.side_effect = HTTPError(None, None, "not found", None, None)
+        with self.assertRaises(HTTPException) as ctx:
+            get_variants("TP53")
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn("not found", str(ctx.exception.detail))
+
+    @patch("variant_service.fetch_variant")
+    def test_get_variant_success(self, mock_fetch):
+        mock_fetch.return_value = {"id": 1, "name": "Variant"}
+        result = get_variant(1)
+        self.assertEqual(result, {"id": 1, "name": "Variant"})
+        mock_fetch.assert_called_with(1)
+
+    @patch("variant_service.fetch_variant")
+    def test_get_variant_http_error(self, mock_fetch):
+        mock_fetch.side_effect = HTTPError(None, None, "not found", None, None)
+        with self.assertRaises(HTTPException) as ctx:
+            get_variant(1)
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertIn("not found", str(ctx.exception.detail))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand unit tests for variant_annotator and variant_service
- add GitHub Actions job to run `python -m unittest`
- include httpx in requirements for FastAPI's test utilities

## Testing
- `python -m unittest`
