### PR TITLE
Update deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,13 @@ name: Deploy to AWS
 on:
   workflow_dispatch:
     inputs:
-      civic_api_key:
-        description: 'CIVIC API key passed to the service'
+      environment:
+        description: 'Target environment to deploy (dev or prod)'
         required: true
+        type: choice
+        options:
+          - dev
+          - prod
 
 jobs:
   deploy:
@@ -25,7 +29,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
-          CIVIC_API_KEY: ${{ github.event.inputs.civic_api_key }}
+          CIVIC_API_KEY: ${{ secrets.CIVIC_API_KEY }}
+          DEPLOY_ENV: ${{ github.event.inputs.environment }}
         run: |
           cdk -a "python infra/app.py" deploy --require-approval never
 

--- a/infra/app.py
+++ b/infra/app.py
@@ -7,7 +7,10 @@ app = cdk.App()
 
 civic_api_key = os.environ.get("CIVIC_API_KEY", "")
 
-VariantServiceStack(app, "VariantServiceStack", civic_api_key=civic_api_key)
+deploy_env = os.environ.get("DEPLOY_ENV", "dev")
+stack_name = f"VariantServiceStack-{deploy_env}"
+
+VariantServiceStack(app, stack_name, civic_api_key=civic_api_key)
 
 app.synth()
 


### PR DESCRIPTION
## Summary
- support dev or prod environment selection for AWS deployments
- store the CIVIC API key in GitHub secrets rather than as a workflow input

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: command not found)*