### PR TITLE
Update docs on AWS hosting and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ python -m unittest
 
 A CDK stack in `infra/` can deploy the service to AWS Fargate behind API Gateway. See [docs/aws_deploy.md](docs/aws_deploy.md) for setup instructions and a GitHub Actions workflow that performs the deployment.
 
+After deployment, note the API Gateway URL and API key printed in the workflow
+logs. Configure Cursor or any other MCP client&mdash;such as Claude Desktop&mdash;
+to use this URL as the tool's `base_url` and supply the API key through its
+authentication settings.
+

--- a/docs/aws_deploy.md
+++ b/docs/aws_deploy.md
@@ -23,7 +23,7 @@ The action builds a Docker image from this repository and provisions:
 2. An Application Load Balancer fronting the service
 3. An API Gateway that requires an API key for access
 
-The generated API key and endpoint URL are printed in the workflow logs as CloudFormation outputs. Use this key when configuring tools in Cursor.
+The generated API key and endpoint URL are printed in the workflow logs as CloudFormation outputs. Use this key when configuring tools in Cursor or any other MCP client, such as Claude Desktop.
 
 The CIVIC API key you supply is passed to the container as the `CIVIC_API_KEY` environment variable.
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -13,9 +13,14 @@ python variant_service.py
 ```json
 {
   "tools": [
-    { "name": "variant_service", "base_url": "http://localhost:8000" }
+{ "name": "variant_service", "base_url": "http://localhost:8000" }
   ]
 }
 ```
 
 Restart Cursor after saving the file. You can then invoke the service from your MCP workflows.
+
+If you have deployed the service to AWS, replace `http://localhost:8000` in the
+example above with the API Gateway URL output during deployment. Provide the
+API key using your client's authentication settings. This same approach works
+for other MCP clients, such as Claude Desktop.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,13 @@ The tool queries the CIViC API each time it runs so information is always up to 
 
 The content of this site is also compiled into a React web app using Shadcn UI under `react_web_app` and published to the `gh-pages` branch.
 
+## Hosting on AWS
+
+You can deploy the service to AWS Fargate using the CDK stack in `infra/`. The
+deployment exposes the API through API Gateway. Configure clients such as Cursor
+or Claude Desktop with the provided URL and API key to access the hosted
+service.
+
 ## Related Documents
 
 - [Product Requirements](prd.txt)


### PR DESCRIPTION
## Summary
- document how to configure AWS-hosted variant service
- mention Cursor and Claude Desktop in docs

## Testing
- `python -m unittest`