### PR TITLE
Add shadcn styled docs page

### DIFF
--- a/react_web_app/components/ui/card.css
+++ b/react_web_app/components/ui/card.css
@@ -1,0 +1,7 @@
+.shadcn-card {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background-color: #f9f9f9;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}

--- a/react_web_app/components/ui/card.jsx
+++ b/react_web_app/components/ui/card.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import './card.css';
+
+export function Card({ children }) {
+  return <div className="shadcn-card">{children}</div>;
+}

--- a/react_web_app/src/App.jsx
+++ b/react_web_app/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from '../components/ui/button';
+import DocsPage from './DocsPage';
 import './index.css';
 
 const docText = `Gene Variant Annotation Service
@@ -28,12 +29,18 @@ Available endpoints:
 Restart Cursor after saving the configuration.`;
 
 export default function App() {
+  const [showDocs, setShowDocs] = React.useState(false);
+
+  if (showDocs) {
+    return <DocsPage onBack={() => setShowDocs(false)} />;
+  }
+
   return (
     <main className="p-4 font-sans">
       <h1 className="text-2xl font-bold mb-4">Gene Variant Service Docs</h1>
       <pre className="whitespace-pre-wrap">{docText}</pre>
       <div className="mt-4">
-        <Button>Shadcn Button</Button>
+        <Button onClick={() => setShowDocs(true)}>View Documentation</Button>
       </div>
     </main>
   );

--- a/react_web_app/src/DocsPage.jsx
+++ b/react_web_app/src/DocsPage.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import './index.css';
+
+export default function DocsPage({ onBack }) {
+  return (
+    <main className="p-4 font-sans">
+      <Button onClick={onBack}>Back</Button>
+      <Card>
+        <h1 className="text-xl font-bold mb-2">Gene Variant Annotation Service</h1>
+        <p>This site provides documentation for the microservice that exposes curated oncology variant information from CIViC. The service is designed for use in Model Context Protocol (MCP) workflows and can also be called directly.</p>
+        <h2 className="text-lg font-semibold mt-4">Getting Started</h2>
+        <p>Run the tool with a gene symbol or variant ID:</p>
+        <pre className="bg-gray-100 p-2 rounded">python variant_annotator.py --gene TP53</pre>
+        <h2 className="text-lg font-semibold mt-4">Updating Data</h2>
+        <p>The tool queries the CIViC API each time it runs so information is always up to date with the latest curated variants and studies.</p>
+        <h2 className="text-lg font-semibold mt-4">Web Documentation</h2>
+        <p>The content of this site is also compiled into a React web app using Shadcn UI under <code>react_web_app</code> and published to the <code>gh-pages</code> branch.</p>
+        <h2 className="text-lg font-semibold mt-4">Related Documents</h2>
+        <ul className="list-disc ml-6">
+          <li><a href="../docs/prd.txt">Product Requirements</a></li>
+          <li><a href="../docs/prd_tasks.md">Task Breakdown</a></li>
+          <li><a href="../docs/mcp.md">Model Context Protocol Integration</a></li>
+          <li><a href="../docs/cursor.md">Configuring in Cursor</a></li>
+        </ul>
+      </Card>
+    </main>
+  );
+}

--- a/react_web_app/src/index.css
+++ b/react_web_app/src/index.css
@@ -3,3 +3,18 @@ body {
   margin: 0;
   padding: 0;
 }
+
+.text-xl { font-size: 1.25rem; }
+.text-lg { font-size: 1.125rem; }
+.font-bold { font-weight: 700; }
+.font-semibold { font-weight: 600; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mt-4 { margin-top: 1rem; }
+.list-disc { list-style-type: disc; }
+.ml-6 { margin-left: 1.5rem; }
+.p-2 { padding: 0.5rem; }
+.bg-gray-100 { background-color: #f3f4f6; }
+.rounded { border-radius: 0.25rem; }
+.font-sans { font-family: sans-serif; }
+.p-4 { padding: 1rem; }


### PR DESCRIPTION
## Summary
- add new shadcn Card component
- provide Documentation page leveraging the Card and Button components
- adjust App component to show documentation page when requested
- extend CSS utilities for simple shadcn style classes

## Testing
- `python -m unittest`