### PR TITLE
Fix docs links in web UI

### DIFF
--- a/.github/workflows/react-gh-pages.yml
+++ b/.github/workflows/react-gh-pages.yml
@@ -32,6 +32,9 @@ jobs:
         run: npm run build
         working-directory: react_web_app
 
+      - name: Copy docs to build output
+        run: cp -r docs react_web_app/dist
+      
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/react_web_app/src/DocsPage.jsx
+++ b/react_web_app/src/DocsPage.jsx
@@ -19,10 +19,10 @@ export default function DocsPage({ onBack }) {
         <p>The content of this site is also compiled into a React web app using Shadcn UI under <code>react_web_app</code> and published to the <code>gh-pages</code> branch.</p>
         <h2 className="text-lg font-semibold mt-4">Related Documents</h2>
         <ul className="list-disc ml-6">
-          <li><a href="../docs/prd.txt">Product Requirements</a></li>
-          <li><a href="../docs/prd_tasks.md">Task Breakdown</a></li>
-          <li><a href="../docs/mcp.md">Model Context Protocol Integration</a></li>
-          <li><a href="../docs/cursor.md">Configuring in Cursor</a></li>
+          <li><a href="docs/prd.txt">Product Requirements</a></li>
+          <li><a href="docs/prd_tasks.md">Task Breakdown</a></li>
+          <li><a href="docs/mcp.md">Model Context Protocol Integration</a></li>
+          <li><a href="docs/cursor.md">Configuring in Cursor</a></li>
         </ul>
       </Card>
     </main>


### PR DESCRIPTION
## Summary
- point docs links at repo paths
- copy docs folder into built site so txt files are available

## Testing
- `python -m unittest`