### PR TITLE
Allow local service run with API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ It can be used to keep oncology variant information up to date and can serve as 
 ```
 python variant_annotator.py --gene TP53
 python variant_annotator.py --variant 1
+python variant_annotator.py --gene TP53 --api-key YOUR_CIVIC_KEY
 ```
 
-The tool prints variant IDs, names and short descriptions retrieved from CIViC.
+Set the `CIVIC_API_KEY` environment variable or pass `--api-key` to provide a
+personal CIViC API key when needed. The tool prints variant IDs, names and
+short descriptions retrieved from CIViC.
 
 ## GitHub Pages
 
@@ -30,6 +33,12 @@ The `variant_service.py` microservice can be used in a Model Context Protocol
 workflow. AI models running on an MCP server can call the service's endpoints to
 retrieve gene variant information. See [docs/mcp.md](docs/mcp.md) for details on
  the available tools. Configuration instructions for [Cursor](https://github.com/getcursor/cursor) are provided in [docs/cursor.md](docs/cursor.md).
+
+To run the service locally, export your CIViC API key and start the FastAPI server:
+
+```bash
+CIVIC_API_KEY=YOUR_CIVIC_KEY python variant_service.py
+```
 
 ## Running Tests
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -5,7 +5,7 @@ To call the gene variant service from [Cursor](https://github.com/getcursor/curs
 1. Start the service locally:
 
 ```bash
-python variant_service.py
+CIVIC_API_KEY=YOUR_CIVIC_KEY python variant_service.py
 ```
 
 2. Update `cursor.json` with the tool configuration:
@@ -19,6 +19,8 @@ python variant_service.py
 ```
 
 Restart Cursor after saving the file. You can then invoke the service from your MCP workflows.
+Ensure the `CIVIC_API_KEY` environment variable is set (or use `--api-key` when running `variant_annotator.py`) so the service can authenticate to the CIViC API when required.
+
 
 If you have deployed the service to AWS, replace `http://localhost:8000` in the
 example above with the API Gateway URL output during deployment. Provide the

--- a/variant_annotator.py
+++ b/variant_annotator.py
@@ -1,14 +1,19 @@
 import argparse
 import json
-from urllib.request import urlopen
+import os
+from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 from typing import List, Dict
 
 CIVIC_BASE_URL = "https://civicdb.org/api"  # open API for cancer variants
+CIVIC_API_KEY_ENV = "CIVIC_API_KEY"
 
 
 def fetch_json(url: str):
-    with urlopen(url) as response:
+    """Fetch JSON data from a URL, using an API key if provided."""
+    api_key = os.environ.get(CIVIC_API_KEY_ENV)
+    request = url if not api_key else Request(url, headers={"X-API-KEY": api_key})
+    with urlopen(request) as response:
         return json.loads(response.read().decode())
 
 
@@ -29,7 +34,11 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--gene", help="Gene symbol to query")
     group.add_argument("--variant", type=int, help="CIViC variant ID to query")
+    parser.add_argument("--api-key", help="CIViC API key", dest="api_key")
     args = parser.parse_args()
+
+    if args.api_key:
+        os.environ[CIVIC_API_KEY_ENV] = args.api_key
 
     try:
         if args.gene:


### PR DESCRIPTION
## Summary
- support a CIViC API key via environment variable or `--api-key`
- document how to run the service locally with Cursor

## Testing
- `python -m unittest`