### PR TITLE
Add SSE usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ To run the service locally, export your CIViC API key and start the FastAPI serv
 CIVIC_API_KEY=YOUR_CIVIC_KEY python variant_service.py
 ```
 
+### Running in SSE
+
+If you have access to an SSE (Secure Shell Environment) session, you can start
+the service there using the same command. Cursor or other MCP clients can then
+connect to the service at the SSE URL (typically `http://localhost:8000`) just
+as if it were running on your local machine.
+
 ## Running Tests
 
 Run the test suite using Python's built-in `unittest` module:

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -8,6 +8,10 @@ To call the gene variant service from [Cursor](https://github.com/getcursor/curs
 CIVIC_API_KEY=YOUR_CIVIC_KEY python variant_service.py
 ```
 
+   The same command works in an SSE (Secure Shell Environment) session if you
+   prefer not to run the service on your local machine. Cursor only needs the
+   service's URL (usually `http://localhost:8000`).
+
 2. Update `cursor.json` with the tool configuration:
 
 ```json

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,19 @@ deployment exposes the API through API Gateway. Configure clients such as Cursor
 or Claude Desktop with the provided URL and API key to access the hosted
 service.
 
+## Running in SSE
+
+The service can also run inside an SSE (Secure Shell Environment) session. Start
+it with your CIViC API key just as you would locally:
+
+```bash
+CIVIC_API_KEY=YOUR_CIVIC_KEY python variant_service.py
+```
+
+Point Cursor or any other MCP client at the SSE server's URL (usually
+`http://localhost:8000`) to use the service without hosting it on your local
+machine.
+
 ## Related Documents
 
 - [Product Requirements](prd.txt)

--- a/react_web_app/src/App.jsx
+++ b/react_web_app/src/App.jsx
@@ -20,6 +20,10 @@ Available endpoints:
    \`\`\`bash
    python variant_service.py
    \`\`\`
+
+   You can also run this command inside an SSE (Secure Shell Environment)
+   session and point Cursor at the SSE URL (typically
+   \\`http://localhost:8000\\`).
 2. Add an entry to your \`cursor.json\` configuration:
    \`\`\`json
    {

--- a/react_web_app/src/docs.js
+++ b/react_web_app/src/docs.js
@@ -117,6 +117,10 @@ To call the gene variant service from [Cursor](https://github.com/getcursor/curs
 python variant_service.py
 \`\`\`
 
+   The same command can be run inside an SSE (Secure Shell Environment) session
+   if you prefer not to host the service on your machine. Cursor only needs the
+   URL of the running server, typically `http://localhost:8000`.
+
 2. Update \`cursor.json\` with the tool configuration:
 \`\`\`json
 {


### PR DESCRIPTION
## Summary
- document running the variant service in an SSE session
- mention SSE in Cursor configuration docs
- add SSE info to the React site

## Testing
- `python -m unittest`