### PR TITLE
Fix escaping in template string

### DIFF
--- a/react_web_app/src/App.jsx
+++ b/react_web_app/src/App.jsx
@@ -22,8 +22,8 @@ Available endpoints:
    \`\`\`
 
    You can also run this command inside an SSE (Secure Shell Environment)
-   session and point Cursor at the SSE URL (typically
-   \\`http://localhost:8000\\`).
+    session and point Cursor at the SSE URL (typically
+    \`http://localhost:8000\`).
 2. Add an entry to your \`cursor.json\` configuration:
    \`\`\`json
    {


### PR DESCRIPTION
## Summary
- fix escaping of backticks in App.jsx

## Testing
- `python -m unittest`