### PR TITLE
Add backend unit tests and workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,22 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: python -m unittest discover tests

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,60 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import variant_annotator
+import variant_service
+
+
+class MockResponse:
+    def __init__(self, data):
+        self.data = data
+
+    def read(self):
+        return json.dumps(self.data).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def mock_urlopen_factory(data):
+    def _mock_urlopen(url):
+        return MockResponse(data)
+    return _mock_urlopen
+
+
+class BackendTest(unittest.TestCase):
+    def test_fetch_variants_by_gene(self):
+        data = [{"id": 1, "name": "Var"}]
+        with patch.object(variant_annotator, "urlopen", mock_urlopen_factory(data)):
+            variants = variant_annotator.fetch_variants_by_gene("TP53")
+        self.assertEqual(variants, data)
+
+    def test_fetch_variant(self):
+        data = {"id": 2, "name": "V2"}
+        with patch.object(variant_annotator, "urlopen", mock_urlopen_factory(data)):
+            variant = variant_annotator.fetch_variant(2)
+        self.assertEqual(variant, data)
+
+    def test_health(self):
+        response = variant_service.health()
+        self.assertEqual(response, {"status": "ok"})
+
+    def test_get_variants_endpoint(self):
+        data = [{"id": 3, "name": "Var3"}]
+        with patch.object(variant_annotator, "urlopen", mock_urlopen_factory(data)):
+            response = variant_service.get_variants("TP53")
+        self.assertEqual(response, data)
+
+    def test_get_variant_endpoint(self):
+        data = {"id": 4, "name": "Var4"}
+        with patch.object(variant_annotator, "urlopen", mock_urlopen_factory(data)):
+            response = variant_service.get_variant(4)
+        self.assertEqual(response, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add backend unit tests covering service endpoints and fetch functions
- run these tests in GitHub Actions

## Testing
- `python -m unittest discover tests`