### PR TITLE
Fix docs.js escape error

### DIFF
--- a/react_web_app/src/docs.js
+++ b/react_web_app/src/docs.js
@@ -119,7 +119,7 @@ python variant_service.py
 
    The same command can be run inside an SSE (Secure Shell Environment) session
    if you prefer not to host the service on your machine. Cursor only needs the
-   URL of the running server, typically `http://localhost:8000`.
+   URL of the running server, typically \`http://localhost:8000\`.
 
 2. Update \`cursor.json\` with the tool configuration:
 \`\`\`json


### PR DESCRIPTION
## Summary
- escape backticks around localhost URL in `cursorConfig`

## Testing
- `python -m unittest`